### PR TITLE
Fix vmq-admin, migrations, and merge in upstream repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,53 @@
+sudo: 'required'
+services:
+  - 'docker'
+
+language: bash
+
+stages:
+  - name: test
+    if: (type = pull_request)
+  - name: deploy
+    if: (type != pull_request) AND (branch = master)
+
+jobs:
+  include:
+    - &buildandtest
+      stage: test
+      before_script: docker build --build-arg TARGET=${TARGET} -t vmq-travis -f ${DOCKERFILE} .
+      script: docker run vmq-travis vernemq
+      env:
+        - DOCKERFILE=Dockerfile TARGET=rel
+
+    - <<: *buildandtest
+      env:
+        - DOCKERFILE=Dockerfile.alpine TARGET=rel
+
+    - &buildlatest
+      stage: deploy
+      before_script: docker build --build-arg TARGET=${TARGET} -t vmq-travis -f ${DOCKERFILE} .
+      env:
+        - DOCKERFILE=Dockerfile TARGET=rel TAG_SUFFIX=""
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+        - docker tag vmq-travis vernemq/vernemq:latest$TAG_SUFFIX
+        - docker push vernemq/vernemq:latest$TAG_SUFFIX
+
+    - <<: *buildlatest
+      env:
+        - DOCKERFILE=Dockerfile.alpine TARGET=rel TAG_SUFFIX="-alpine"
+
+    - &buildtag 
+      stage: deploy
+      if: (tag IS present)
+      before_script: docker build --build-arg TARGET=${TARGET} -t vmq-travis -f ${DOCKERFILE} .
+      env:
+        - DOCKERFILE=Dockerfile TARGET=rel TAG_SUFFIX=""
+      script:
+        - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+        - docker tag vmq-travis vernemq/vernemq:$TRAVIS_TAG$TAG_SUFFIX
+        - docker push vernemq/vernemq:$TRAVIS_TAG$TAG_SUFFIX
+
+    - <<: *buildtag
+      env:
+        - DOCKERFILE=Dockerfile.alpine TARGET=rel TAG_SUFFIX="-alpine"

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM erlang:20.3 AS build-env
+FROM erlang:20.3-alpine AS build-env
 
 WORKDIR /vernemq-build
 
@@ -11,21 +11,19 @@ ENV DOCKER_VERNEMQ_KUBERNETES_APP_LABEL vernemq
 ENV DOCKER_VERNEMQ_LOG__CONSOLE console
 
 RUN \
-    apt-get update \
-    && apt-get -y install build-essential git libssl-dev  \
+    apk --no-cache --update --available upgrade \
+    && apk add --no-cache git autoconf build-base bsd-compat-headers cmake openssl-dev bash \
     && git clone -b $VERNEMQ_GIT_REF --single-branch --depth 1 $VERNEMQ_REPO .
 
 ADD bin/build.sh build.sh
 
 RUN ./build.sh $TARGET
 
-
-FROM debian:stretch-slim
+FROM alpine:3.8
 
 RUN \
-    apt-get update \
-    && apt-get -y install openssl iproute2 curl jq \
-	&& rm -rf /var/lib/apt/lists/*
+    apk --no-cache --update --available upgrade \
+    && apk add --no-cache ncurses-libs openssl libstdc++ jq curl bash
 
 # Defaults
 ENV DOCKER_VERNEMQ_KUBERNETES_APP_LABEL vernemq
@@ -38,7 +36,7 @@ COPY --from=build-env /vernemq-build/release /vernemq
 ADD files/vm.args /vernemq/etc/vm.args
 
 RUN addgroup vernemq && \
-    adduser --system --ingroup vernemq --home /vernemq --disabled-password vernemq && \
+    adduser -H -D -G vernemq -h /vernemq vernemq && \
     chown -R vernemq:vernemq /vernemq && \
     ln -s /vernemq/etc /etc/vernemq && \
     ln -s /vernemq/data /var/lib/vernemq && \

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,144 @@
+# docker-vernemq
+
+## What is VerneMQ?
+
+VerneMQ is a high-performance, distributed MQTT message broker. It scales
+horizontally and vertically on commodity hardware to support a high number of
+concurrent publishers and consumers while maintaining low latency and fault
+tolerance. VerneMQ is the reliable message hub for your IoT platform or smart
+products.
+
+VerneMQ is an Apache2 licensed distributed MQTT broker, developed in Erlang.
+
+## How to use this image
+
+### Start a VerneMQ cluster node
+
+    docker run --name vernemq1 -d erlio/docker-vernemq
+
+Somtimes you need to configure a forwarding for ports (on a Mac for example):
+
+    docker run -p 1883:1883 --name vernemq1 -d erlio/docker-vernemq
+
+This starts a new node that listens on 1883 for MQTT connections and on 8080 for MQTT over websocket connections. However, at this moment the broker won't be able to authenticate the connecting clients. To allow anonymous clients use the ```DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on``` environment variable.
+
+    docker run -e "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on" --name vernemq1 -d erlio/docker-vernemq
+
+### Autojoining a VerneMQ cluster
+
+This allows a newly started container to automatically join a VerneMQ cluster. Assuming you started your first node like the example above you could autojoin the cluster (which currently consists of a single container 'vernemq1') like the following:
+
+    docker run -e "DOCKER_VERNEMQ_DISCOVERY_NODE=<IP-OF-VERNEMQ1>" --name vernemq2 -d erlio/docker-vernemq
+
+(Note, you can find the IP of a docker container using `docker inspect <containername/cid> | grep \"IPAddress\"`).
+
+### Automated clustering on Kubernetes
+
+When running VerneMQ inside Kubernetes, it is possible to cause pods matching a specific label to cluster altogether automatically.
+This feature uses Kubernetes' API to discover other peers, and relies on the [default pod service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) which has to be enabled.
+
+Simply set ```DOCKER_VERNEMQ_DISCOVERY_KUBERNETES=1``` in your pod's environment, and expose your own pod name through ```MY_POD_NAME``` . By default, this setting will cause all pods in the same namespace with the ```app=vernemq``` label to join the same cluster. Cluster name (defaults to `cluster.local`), namespace and label settings can be overridden with ```DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME```, ```DOCKER_VERNEMQ_KUBERNETES_NAMESPACE``` and ```DOCKER_VERNEMQ_KUBERNETES_APP_LABEL``` respectively.
+
+An example configuration of your pod's environment looks like this:
+
+    env:
+      - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
+        value: "1"
+      - name: MY_POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      - name: DOCKER_VERNEMQ_KUBERNETES_APP_LABEL
+        value: "myverneinstance"
+
+When enabling Kubernetes autoclustering, don't set ```DOCKER_VERNEMQ_DISCOVERY_NODE```.
+
+> If you encounter "SSL certification error (subject name does not match the host name)" like below, you may try to set ```DOCKER_VERNEMQ_KUBERNETES_INSECURE``` to "1".
+>
+> ```text
+> kubectl logs vernemq-0
+>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+>                                  Dload  Upload   Total   Spent    Left  Speed
+>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (51) SSL: certificate subject name 'client' does not match target host name 'kubernetes.default.svc.cluster.local'
+>   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+>                                  Dload  Upload   Total   Spent    Left  Speed
+>   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (51) SSL: certificate subject name 'client' does not match target host name 'kubernetes.default.svc.cluster.local'
+> vernemq failed to start within 15 seconds,
+> see the output of 'vernemq console' for more information.
+> If you want to wait longer, set the environment variable
+> WAIT_FOR_ERLANG to the number of seconds to wait.
+> ...
+> ```
+
+### Checking cluster status
+
+To check if the bove containers have successfully clustered you can issue the ```vmq-admin``` command:
+
+    docker exec vernemq1 vmq-admin cluster show
+    +--------------------+-------+
+    |        Node        |Running|
+    +--------------------+-------+
+    |VerneMQ@172.17.0.151| true  |
+    |VerneMQ@172.17.0.152| true  |
+    +--------------------+-------+
+
+If you started VerneMQ cluster inside Kubernetes using ```DOCKER_VERNEMQ_DISCOVERY_KUBERNETES=1```, you can execute ```vmq-admin``` through ```kubectl```:
+
+    kubectl exec vernemq-0 -- vmq-admin cluster show
+    +---------------------------------------------------+-------+
+    |                       Node                        |Running|
+    +---------------------------------------------------+-------+
+    |VerneMQ@vernemq-0.vernemq.default.svc.cluster.local| true  |
+    |VerneMQ@vernemq-1.vernemq.default.svc.cluster.local| true  |
+    +---------------------------------------------------+-------+
+
+All ```vmq-admin``` commands are available. See https://vernemq.com/docs/administration/ for more information.
+
+### VerneMQ Configuration
+
+All configuration parameters that are available in `vernemq.conf` can be defined
+using the `DOCKER_VERNEMQ` prefix followed by the confguration parameter name.
+E.g: `allow_anonymous=on` is `-e "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on"` or
+`allow_register_during_netsplit=on` is
+`-e "DOCKER_VERNEMQ_ALLOW_REGISTER_DURING_NETSPLIT=on"`. All available configuration
+parameters can be found on https://vernemq.com/docs/configuration/.
+
+#### Logging
+
+VerneMQ store crash and error log files in `/var/log/vernemq/`, and, by default, 
+doesn't write console log to the disk to avoid filling the container disk space.
+However this behaviour can be changed by setting the environment variable `DOCKER_VERNEMQ_LOG__CONSOLE` to `both` 
+which tells VerneMQ to send logs to stdout and `/var/log/vernemq/console.log`.
+For more information please see VerneMQ logging documentation: https://docs.vernemq.com/configuring-vernemq/logging
+
+#### Remarks
+
+Some of our configuration variables contain dots `.`. For example if you want to
+adjust the log level of VerneMQ you'd use `-e
+"DOCKER_VERNEMQ_LOG.CONSOLE.LEVEL=debug"`. However, some container platforms
+such as Kubernetes don't support dots and other special characters in
+environment variables. If you are on such a platform you could substitute the
+dots with two underscores `__`. The example above would look like `-e
+"DOCKER_VERNEMQ_LOG__CONSOLE__LEVEL=debug"`.
+
+There some some exceptions on configuration names contains dots. You can see follow examples:
+
+format in vernemq.conf | format in environment variable name
+---------------------- | ------------------------------------
+ `vmq_webhooks.pool_timeout = 60000` | `DOCKER_VERNEMQ_VMQ_WEBHOOKS__POOL_timeout=6000`
+ `vmq_webhooks.pool_timeout = 60000` | `DOCKER_VERNEMQ_VMQ_WEBHOOKS.pool_timeout=60000`
+
+
+
+
+#### File Based Authentication
+
+You can set up [File Based Authentication](https://vernemq.com/docs/configuration/authentication.html)
+by adding users and passwords as environment variables as follows:
+
+`DOCKER_VERNEMQ_USER_<USERNAME>='password'`
+
+where `<USERNAME>` is the username you want to use. This can be done as many times as necessary
+to create the users you want. The usernames will always be created in lowercase
+
+*CAVEAT* - You cannot have a `=` character in your password.

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+if [ "$1" = "swc" ]
+then
+    make swc
+    mv _build/swc/rel/vernemq release
+else
+    make rel
+    mv _build/default/rel/vernemq release
+fi

--- a/bin/rand_cluster_node.escript
+++ b/bin/rand_cluster_node.escript
@@ -1,0 +1,18 @@
+%% -*- erlang -*-
+main([ThisNode]) ->
+    code:add_paths(filelib:wildcard("/usr/lib/vernemq/lib/*/ebin")),
+    FileName = "/var/lib/vernemq/meta/peer_service/cluster_state",
+    case filelib:is_regular(FileName) of
+        true ->
+            {ok, Bin} = file:read_file(FileName),
+            {ok, State} = riak_dt_orswot:from_binary(Bin),
+            AThisNode = list_to_atom(ThisNode),
+            TargetNodes = riak_dt_orswot:value(State) -- [AThisNode],
+            L = lists:foldl(
+                  fun(N, Acc) ->
+                          Acc ++ atom_to_list(N) ++ "\n" 
+                  end, "", TargetNodes),
+            io:format(L);
+        false ->
+            io:format("")
+    end.

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+IP_ADDRESS=$(ip -4 addr show ${DOCKER_NET_INTERFACE:-eth0} | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
+IP_ADDRESS=${DOCKER_IP_ADDRESS:-${IP_ADDRESS}}
+
+# Ensure the Erlang node name is set correctly
+if env | grep "DOCKER_VERNEMQ_NODENAME" -q; then
+    sed -i.bak -r "s/-name VerneMQ@.+/-name VerneMQ@${DOCKER_VERNEMQ_NODENAME}/" /vernemq/etc/vm.args
+else
+    sed -i.bak -r "s/-name VerneMQ@.+/-name VerneMQ@${IP_ADDRESS}/" /vernemq/etc/vm.args
+fi
+
+if env | grep "DOCKER_VERNEMQ_DISCOVERY_NODE" -q; then
+    sed -i.bak -r "/-eval.+/d" /vernemq/etc/vm.args 
+    echo "-eval \"vmq_server_cmd:node_join('VerneMQ@${DOCKER_VERNEMQ_DISCOVERY_NODE}')\"" >> /vernemq/etc/vm.args
+fi
+
+# If you encounter "SSL certification error (subject name does not match the host name)", you may try to set DOCKER_VERNEMQ_KUBERNETES_INSECURE to "1".
+insecure=""
+if env | grep "DOCKER_VERNEMQ_KUBERNETES_INSECURE" -q; then
+    insecure="--insecure"
+fi
+
+if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
+    DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME=${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME:-cluster.local}
+    # Let's get the namespace if it isn't set
+    DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`}
+    # Let's set our nodename correctly
+    VERNEMQ_KUBERNETES_SUBDOMAIN=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=app=$DOCKER_VERNEMQ_KUBERNETES_APP_LABEL -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')
+    if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
+        VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
+    else
+        VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
+    fi
+
+    sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${VERNEMQ_KUBERNETES_HOSTNAME}/" /vernemq/etc/vm.args
+    # Hack into K8S DNS resolution (temporarily)
+    kube_pod_names=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=app=$DOCKER_VERNEMQ_KUBERNETES_APP_LABEL -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
+    for kube_pod_name in $kube_pod_names;
+    do
+        if [ $kube_pod_name == "null" ]
+            then
+                echo "Kubernetes discovery selected, but no pods found. Maybe we're the first?"
+                echo "Anyway, we won't attempt to join any cluster."
+                break
+        fi
+        if [ $kube_pod_name != $MY_POD_NAME ]
+            then
+                echo "Will join an existing Kubernetes cluster with discovery node at ${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}"
+                echo "-eval \"vmq_server_cmd:node_join('VerneMQ@${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}')\"" >> /vernemq/etc/vm.args
+                break
+        fi
+    done
+fi
+
+if [ -f /vernemq/etc/vernemq.conf.local ]; then
+    cp /vernemq/etc/vernemq.conf.local /vernemq/etc/vernemq.conf
+else
+    sed -i '/########## Start ##########/,/########## End ##########/d' /vernemq/etc/vernemq.conf
+
+    echo "########## Start ##########" >> /vernemq/etc/vernemq.conf
+
+    env | grep DOCKER_VERNEMQ | grep -v 'DISCOVERY_NODE\|KUBERNETES\|DOCKER_VERNEMQ_USER' | cut -c 16- | awk '{match($0,/^[A-Z0-9_]*/)}{print tolower(substr($0,RSTART,RLENGTH)) substr($0,RLENGTH+1)}' | sed 's/__/./g' >> /vernemq/etc/vernemq.conf
+
+    users_are_set=$(env | grep DOCKER_VERNEMQ_USER)
+    if [ ! -z "$users_are_set" ]; then
+        echo "vmq_passwd.password_file = /vernemq/etc/vmq.passwd" >> /vernemq/etc/vernemq.conf
+        touch /vernemq/etc/vmq.passwd
+    fi
+
+    for vernemq_user in $(env | grep DOCKER_VERNEMQ_USER); do
+        username=$(echo $vernemq_user | awk -F '=' '{ print $1 }' | sed 's/DOCKER_VERNEMQ_USER_//g' | tr '[:upper:]' '[:lower:]')
+        password=$(echo $vernemq_user | awk -F '=' '{ print $2 }')
+        /vernemq/bin/vmq-passwd /vernemq/etc/vmq.passwd $username <<EOF
+$password
+$password
+EOF
+    done
+
+    echo "erlang.distribution.port_range.minimum = 9100" >> /vernemq/etc/vernemq.conf
+    echo "erlang.distribution.port_range.maximum = 9109" >> /vernemq/etc/vernemq.conf
+    echo "listener.tcp.default = ${IP_ADDRESS}:1883" >> /vernemq/etc/vernemq.conf
+    echo "listener.ws.default = ${IP_ADDRESS}:8080" >> /vernemq/etc/vernemq.conf
+    echo "listener.vmq.clustering = ${IP_ADDRESS}:44053" >> /vernemq/etc/vernemq.conf
+    echo "listener.http.metrics = ${IP_ADDRESS}:8888" >> /vernemq/etc/vernemq.conf
+
+    echo "########## End ##########" >> /vernemq/etc/vernemq.conf
+fi
+
+# Check configuration file
+/vernemq/bin/vernemq config generate 2>&1 > /dev/null | tee /tmp/config.out | grep error
+
+if [ $? -ne 1 ]; then
+    echo "configuration error, exit"
+    echo "$(cat /tmp/config.out)"
+    exit $?
+fi
+
+pid=0
+
+# SIGUSR1-handler
+siguser1_handler() {
+    echo "stopped"
+}
+
+# SIGTERM-handler
+sigterm_handler() {
+    if [ $pid -ne 0 ]; then
+        # this will stop the VerneMQ process
+        /vernemq/bin/vmq-admin cluster leave node=VerneMQ@$IP_ADDRESS -k > /dev/null
+        wait "$pid"
+    fi
+    exit 143; # 128 + 15 -- SIGTERM
+}
+
+# Setup OS signal handlers
+trap 'siguser1_handler' SIGUSR1
+trap 'sigterm_handler' SIGTERM
+
+# Start VerneMQ
+/vernemq/bin/vernemq console -noshell -noinput $@
+pid=$(ps aux | grep '[b]eam.smp' | awk '{print $2}')
+wait $pid

--- a/files/vm.args
+++ b/files/vm.args
@@ -1,0 +1,12 @@
++P 256000
+-env ERL_MAX_ETS_TABLES 256000
+-env ERL_CRASH_DUMP /erl_crash.dump
+-env ERL_FULLSWEEP_AFTER 0
+-env ERL_MAX_PORTS 65536
++A 64
+-setcookie vmq
+-name VerneMQ@127.0.0.1
++K true
++W w
+-smp enable
++zdbbl 32768

--- a/mqtt-scripts/add-user.sub
+++ b/mqtt-scripts/add-user.sub
@@ -16,7 +16,7 @@ function subscribe()
         -P "$(cat /run/secrets/mqtt_password)" \
        --cafile /run/secrets/ca  2>&1)
     do
-        echo "Couldn't connect to MQTT. Sleeping."
+        echo "Couldn't connect to MQTT. Response: $response"
         sleep 5
     done
 

--- a/shell-migrations/20180826171133-link-config-migrate.sh
+++ b/shell-migrations/20180826171133-link-config-migrate.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-ln -s /etc/vernemq.conf /etc/vernemq/vernemq.conf.local
+ln -s /vernemq/vernemq.conf /vernemq/etc/vernemq.conf.local

--- a/shell-migrations/shared/create-users.sh
+++ b/shell-migrations/shared/create-users.sh
@@ -6,14 +6,14 @@ add_user_to_vernemq()
 {
     # Need to make sure the create flag gets passed if the passwd file doesn't exist.
     create=""
-    if [ ! -f /etc/vernemq/vmq.passwd ]
+    if [ ! -f /vernemq/etc/vmq.passwd ]
     then
         create="-c"
 
     fi
     expect - <<EOF
 set timeout -1
-spawn vmq-passwd $create /etc/vernemq/vmq.passwd $1
+spawn vmq-passwd $create /vernemq/etc/vmq.passwd $1
 match_max 100000
 expect -exact "Password: "
 send -- "$2\r"
@@ -24,6 +24,6 @@ expect eof
 EOF
     echo "Done with expect"
     # TODO: Add user permissions to user creation?
-    #echo "user $1\rtopic \r" >> /etc/vernemq/vmq.acl
+    #echo "user $1\rtopic \r" >> /vernemq/etc/vmq.acl
 
 }

--- a/vernemq.conf
+++ b/vernemq.conf
@@ -578,7 +578,7 @@ plugins.vmq_bridge = off
 # TODO: I'd like this to be referenced as it would allow me to control general 
 # system references, but I'd also like to control dynamically created HALs.
 # I kinda think I'll just create migrations that'll add to this file.
-vmq_acl.acl_file = /etc/vernemq/vmq.acl
+vmq_acl.acl_file = /vernemq/etc/vmq.acl
 
 ## set the acl reload interval in seconds, the value 0 disables
 ## the automatic reloading of the acl file.
@@ -595,7 +595,7 @@ vmq_acl.acl_reload_interval = 10
 ## 
 ## Acceptable values:
 ##   - the path to a file
-vmq_passwd.password_file = /etc/vernemq/vmq.passwd
+vmq_passwd.password_file = /vernemq/etc/vmq.passwd
 
 ## set the password reload interval in seconds, the value 0
 ## disables the automatic reloading of the password file.
@@ -1012,7 +1012,7 @@ log.console.level = info
 ## 
 ## Acceptable values:
 ##   - the path to a file
-log.console.file = /var/log/vernemq/console.log
+log.console.file = /vernemq/etc/console.log
 
 ## The file where error messages will be logged.
 ## 
@@ -1020,7 +1020,7 @@ log.console.file = /var/log/vernemq/console.log
 ## 
 ## Acceptable values:
 ##   - the path to a file
-log.error.file = /var/log/vernemq/error.log
+log.error.file = /vernemq/etc/error.log
 
 ## When set to 'on', enables log output to syslog.
 ## 

--- a/vernemq.conf
+++ b/vernemq.conf
@@ -246,7 +246,7 @@ listener.mountpoint = off
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## listener.ssl.cafile = /etc/vernemq/cacerts.pem
+## listener.ssl.cafile = /vernemq/etc/cacerts.pem
 listener.ssl.cafile = /run/secrets/ca
 
 ## 
@@ -254,7 +254,7 @@ listener.ssl.cafile = /run/secrets/ca
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## listener.https.cafile = /etc/vernemq/cacerts.pem
+## listener.https.cafile = /vernemq/etc/cacerts.pem
 listener.https.cafile = /run/secrets/ca
 
 ## Set the path to the PEM encoded server certificate
@@ -269,7 +269,7 @@ listener.https.cafile = /run/secrets/ca
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## listener.ssl.certfile = /etc/vernemq/cert.pem
+## listener.ssl.certfile = /vernemq/etc/cert.pem
 listener.ssl.certfile = /run/secrets/mqtt_cert
 
 ## 
@@ -277,7 +277,7 @@ listener.ssl.certfile = /run/secrets/mqtt_cert
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## listener.https.certfile = /etc/vernemq/cert.pem
+## listener.https.certfile = /vernemq/etc/cert.pem
 listener.https.certfile = /run/secrets/mqtt_cert
 
 ## Set the path to the PEM encoded key file on the protocol
@@ -292,7 +292,7 @@ listener.https.certfile = /run/secrets/mqtt_cert
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## listener.ssl.keyfile = /etc/vernemq/key.pem
+## listener.ssl.keyfile = /vernemq/etc/key.pem
 listener.ssl.keyfile = /run/secrets/mqtt_key
 
 ## 
@@ -300,14 +300,14 @@ listener.ssl.keyfile = /run/secrets/mqtt_key
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## listener.vmqs.keyfile = /etc/vernemq/key.pem
+## listener.vmqs.keyfile = /vernemq/etc/key.pem
 
 ## 
 ## Default: 
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## listener.https.keyfile = /etc/vernemq/key.pem
+## listener.https.keyfile = /vernemq/etc/key.pem
 listener.https.keyfile = /run/secrets/mqtt_key
 
 ## Set the list of allowed ciphers (each separated with a colon),
@@ -571,7 +571,7 @@ plugins.vmq_bridge = off
 
 ## Set the path to an access control list file.
 ## 
-## Default: /etc/vernemq/vmq.acl
+## Default: /vernemq/etc/vmq.acl
 ## 
 ## Acceptable values:
 ##   - the path to a file
@@ -591,7 +591,7 @@ vmq_acl.acl_reload_interval = 10
 
 ## Set the path to a password file.
 ## 
-## Default: /etc/vernemq/vmq.passwd
+## Default: /vernemq/etc/vmq.passwd
 ## 
 ## Acceptable values:
 ##   - the path to a file
@@ -915,7 +915,7 @@ vmq_diversity.auth_redis.enabled = off
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## vmq_bridge.ssl.sbr0.cafile = /etc/vernemq/cacerts.pem
+## vmq_bridge.ssl.sbr0.cafile = /vernemq/etc/cacerts.pem
 
 ## Define the path to a folder containing
 ## the PEM encoded CA certificates that are trusted.
@@ -924,7 +924,7 @@ vmq_diversity.auth_redis.enabled = off
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## vmq_bridge.ssl.sbr0.capath = /etc/vernemq/cacerts
+## vmq_bridge.ssl.sbr0.capath = /vernemq/etc/cacerts
 
 ## Set the path to the PEM encoded server certificate.
 ## 
@@ -932,7 +932,7 @@ vmq_diversity.auth_redis.enabled = off
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## vmq_bridge.ssl.sbr0.certfile = /etc/vernemq/cert.pem
+## vmq_bridge.ssl.sbr0.certfile = /vernemq/etc/cert.pem
 
 ## Set the path to the PEM encoded key file.
 ## 
@@ -940,7 +940,7 @@ vmq_diversity.auth_redis.enabled = off
 ## 
 ## Acceptable values:
 ##   - the path to a file
-## vmq_bridge.ssl.sbr0.keyfile = /etc/vernemq/key.pem
+## vmq_bridge.ssl.sbr0.keyfile = /vernemq/etc/key.pem
 
 ## When using certificate based TLS, the bridge will attempt to verify the
 ## hostname provided in the remote certificate matches the host/address being


### PR DESCRIPTION
For some reason, the vmq-admin tool stops working if ANY port is set. Fortunately, I was able to use NGINX to do the port forwarding instead. See https://github.com/SciFiFarms/TechnoCore-NGINX/pull/1 for how I did that on the NGINX end. 

Additionally, it looks like the file locations for VerneMQ changed. Moved from /etc/vernemq to /vernemq/etc. 

Finally, I found I needed to add my changes to the image Dockerfile rather than my own. So I merged in the upstream repo and made my changes. This had the added benefit of running the service as the vernemq user rather than root. 